### PR TITLE
[openstack] Add firewall to openstack dashboard

### DIFF
--- a/manifests/openstack/dashboard.pp
+++ b/manifests/openstack/dashboard.pp
@@ -1,3 +1,13 @@
-class profile::openstack::dashboard {
+class profile::openstack::dashboard(
+  $manage_firewall = true,
+  $firewall_extras = {},
+) {
   include ::horizon
+
+  if $manage_firewall {
+    profile::firewall::rule { '235 openstack-dashboard accept tcp':
+      port   => [80,443],
+      extras => $firewall_extras
+    }
+  }
 }


### PR DESCRIPTION
Currently adds both 443 and 80